### PR TITLE
Leanify package, add resamplings to dictionary

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -78,3 +78,4 @@ Suggests:
     rpart,
     directlabels
 VignetteBuilder: knitr
+RoxygenNote: 7.3.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Description: A supervised learning algorithm inputs a train set,
  test accuracy for each group; other is usually somewhat less accurate
  than same; other can be just as bad as featureless baseline when the
  groups have different patterns).
- For more information, 
+ For more information,
  <https://tdhock.github.io/blog/2023/R-gen-new-subsets/>
  describes the method in depth.
  How many train samples are required to get accurate predictions on a
@@ -78,4 +78,3 @@ Suggests:
     rpart,
     directlabels
 VignetteBuilder: knitr
-RoxygenNote: 7.3.1

--- a/R/ResamplingSameOtherCV.R
+++ b/R/ResamplingSameOtherCV.R
@@ -24,7 +24,7 @@ ResamplingSameOtherCV = R6::R6Class(
       }
       reserved.names <- c(
         "row_id", "fold", "subset", "display_row",
-        "train.subsets", "test.fold", "test.subset", "iteration", 
+        "train.subsets", "test.fold", "test.subset", "iteration",
         "test", "train", "algorithm", "uhash", "nr", "task", "task_id",
         "learner", "learner_id", "resampling", "resampling_id",
         "prediction")
@@ -106,7 +106,7 @@ ResamplingSameOtherCV = R6::R6Class(
           rows="fold",
           display_row=min(display_row),
           display_end=max(display_row)
-        ), by=.(subset, fold)])        
+        ), by=.(subset, fold)])
       self$instance <- list(
         iteration.dt=iteration.dt,
         id.dt=id.fold.subsets[order(row_id)],

--- a/R/ResamplingVariableSizeTrainCV.R
+++ b/R/ResamplingVariableSizeTrainCV.R
@@ -22,8 +22,7 @@ ResamplingVariableSizeTrainCV = R6::R6Class(
     instantiate = function(task) {
       task = mlr3::assert_task(mlr3::as_task(task))
       strata <- if(is.null(task$strata)){
-        data.dt <- task$data()
-        data.table(N=nrow(data.dt), row_id=list(1:nrow(data.dt)))
+        data.table(N=nrow(task$nrow), row_id=list(1:nrow(task$nrow)))
       }else task$strata
       strata.list <- lapply(strata$row_id, private$.sample, task = task)
       folds = private$.combine(strata.list)[order(row_id)]

--- a/R/ResamplingVariableSizeTrainCV.R
+++ b/R/ResamplingVariableSizeTrainCV.R
@@ -22,7 +22,7 @@ ResamplingVariableSizeTrainCV = R6::R6Class(
     instantiate = function(task) {
       task = mlr3::assert_task(mlr3::as_task(task))
       strata <- if(is.null(task$strata)){
-        data.table(N=nrow(task$nrow), row_id=list(1:nrow(task$nrow)))
+        data.table(N=task$nrow, row_id=list(seq_len(task$nrow)))
       }else task$strata
       strata.list <- lapply(strata$row_id, private$.sample, task = task)
       folds = private$.combine(strata.list)[order(row_id)]

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,1 +1,17 @@
+register_mlr3 = function() {
+  mlr_resamplings = utils::getFromNamespace("mlr_resamplings", ns = "mlr3")
+  mlr_resamplings$add("variable_size_train_cv", function() ResamplingVariableSizeTrainCV$new())
+  mlr_resamplings$add("same_other_sizes_cv", function() ResamplingSameOtherSizesCV$new())
+}
+
+.onLoad = function(libname, pkgname) { # nolint
+  # Configure Logger:
+  assign("lg", lgr::get_logger("mlr3"), envir = parent.env(environment()))
+  if (Sys.getenv("IN_PKGDOWN") == "true") {
+    lg$set_threshold("warn") # nolint
+  }
+
+  mlr3misc::register_namespace_callback(pkgname, "mlr3", register_mlr3)
+}
+
 leanify_package()

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,1 @@
+leanify_package()

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,7 +1,6 @@
 register_mlr3 = function() {
   mlr_resamplings = utils::getFromNamespace("mlr_resamplings", ns = "mlr3")
-  mlr_resamplings$add("variable_size_train_cv", function() ResamplingVariableSizeTrainCV$new())
-  mlr_resamplings$add("same_other_sizes_cv", function() ResamplingSameOtherSizesCV$new())
+  mlr_resamplings$add("same_other_sizes_cv", ResamplingSameOtherSizesCV)
 }
 
 .onLoad = function(libname, pkgname) { # nolint
@@ -14,4 +13,4 @@ register_mlr3 = function() {
   mlr3misc::register_namespace_callback(pkgname, "mlr3", register_mlr3)
 }
 
-leanify_package()
+mlr3misc::leanify_package()


### PR DESCRIPTION
Summary of the PR: 

* `leanify`ing a package moves the code of the methods into the `mlr3resampling` namespace. The methods of the R6 instances then just call into these functions. In the past we often had problems with very large object sizes and this mitigates this. 
* the resamplings are added to the `mlr3::mlr_resamplings` dictionary. This allows to construct resamplings using `rsmp("<resampling-id>")`, which we recommend over the `Resampling$new()` syntax
* removed one unnecessary call to `task$data()`