### PR TITLE
compatibility: mlr3 1.0.0

### DIFF
--- a/R/ResamplingBase.R
+++ b/R/ResamplingBase.R
@@ -7,6 +7,7 @@ ResamplingBase = R6::R6Class(
     instance = NULL,
     task_hash = NA_character_,
     task_nrow = NA_integer_,
+    task_row_hash = NA_character_,
     duplicated_ids = NULL,
     man = NULL,
     initialize = function(id, param_set = ps(), duplicated_ids = FALSE, label = NA_character_, man = NA_character_) {

--- a/R/ResamplingSameOtherCV.R
+++ b/R/ResamplingSameOtherCV.R
@@ -116,6 +116,7 @@ ResamplingSameOtherCV = R6::R6Class(
         viz.rect.dt=viz.rect.dt)
       self$task_hash = task$hash
       self$task_nrow = task$nrow
+      self$task_row_hash = task$row_hash
       invisible(self)
     }
   )

--- a/R/ResamplingSameOtherSizesCV.R
+++ b/R/ResamplingSameOtherSizesCV.R
@@ -169,6 +169,7 @@ ResamplingSameOtherSizesCV = R6::R6Class(
         )[, iteration := .I][])
       self$task_hash = task$hash
       self$task_nrow = task$nrow
+      self$task_row_hash = task$row_hash
       invisible(self)
     }
   )

--- a/R/ResamplingVariableSizeTrainCV.R
+++ b/R/ResamplingVariableSizeTrainCV.R
@@ -89,6 +89,7 @@ ResamplingVariableSizeTrainCV = R6::R6Class(
         id.dt=folds)
       self$task_hash = task$hash
       self$task_nrow = task$nrow
+      self$task_row_hash = task$row_hash
       invisible(self)
     }
   )


### PR DESCRIPTION
Hey Toby,

the new mlr3 requires instantiated resamplings to store a hash of the row ids of the task. More info here https://github.com/mlr-org/mlr3/pull/1282. This PR should also work with the current mlr3 CRAN version. Please upload a new mlr3resampling version to CRAN soon.