### PR TITLE
ResamplingBase defines instantiate with common logic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mlr3resampling
 Type: Package
 Title: Resampling Algorithms for 'mlr3' Framework
-Version: 2025.3.30
+Version: 2025.5.15
 Encoding: UTF-8
 Authors@R: c(
     person("Toby", "Hocking",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Changes in version 2025.5.17
+
+- ResamplingBase defines instantiate() which now saves task hash (PR#26, thanks Marc Becker); sub-classes define get_instance().
+
 Changes in version 2025.3.30
 
 - new plot() method for score().

--- a/R/ResamplingBase.R
+++ b/R/ResamplingBase.R
@@ -22,7 +22,7 @@ ResamplingBase = R6::R6Class(
     },
     instantiate = function(task) {
       task = mlr3::assert_task(mlr3::as_task(task))
-      self$instance <- self$get_instance(task)
+      self$instance = self$get_instance(task)
       self$task_hash = task$hash
       self$task_nrow = task$nrow
       self$task_row_hash = task$row_hash

--- a/R/ResamplingBase.R
+++ b/R/ResamplingBase.R
@@ -20,6 +20,14 @@ ResamplingBase = R6::R6Class(
     format = function(...) {
       sprintf("<%s>", class(self)[1L])
     },
+    instantiate = function(task) {
+      task = mlr3::assert_task(mlr3::as_task(task))
+      self$instance <- self$get_instance(task)
+      self$task_hash = task$hash
+      self$task_nrow = task$nrow
+      self$task_row_hash = task$row_hash
+      invisible(self)
+    },
     print = function(...) {
       cat(
         format(self),

--- a/R/ResamplingSameOtherCV.R
+++ b/R/ResamplingSameOtherCV.R
@@ -13,10 +13,9 @@ ResamplingSameOtherCV = R6::R6Class(
         label = "Same versus Other Cross-Validation",
         man = "ResamplingSameOtherCV")
     },
-    instantiate = function(task) {
+    get_instance = function(task) {
       row_id <- fold <- display_row <- . <- train.subsets <- iteration <- NULL
       ## Above to avoid CRAN NOTEs.
-      task = mlr3::assert_task(mlr3::as_task(task))
       if(length(task$col_roles$group)){
         stop("since version 2024.4.15, ResamplingSameOtherCV no longer supports group role (used to avoid splitting related rows into different subsets), but still supports defining same/other/all train groups (now called subset role). Please fix by either changing group role to subset, or using ResamplingSameOtherSizesCV instead (it supports group and subset).")
       }
@@ -109,15 +108,11 @@ ResamplingSameOtherCV = R6::R6Class(
           display_row=min(display_row),
           display_end=max(display_row)
         ), by=.(subset, fold)])
-      self$instance <- list(
+      list(
         iteration.dt=iteration.dt,
         id.dt=id.fold.subsets[order(row_id)],
         viz.set.dt=rbindlist(disp.dt.list),
         viz.rect.dt=viz.rect.dt)
-      self$task_hash = task$hash
-      self$task_nrow = task$nrow
-      self$task_row_hash = task$row_hash
-      invisible(self)
     }
   )
 )

--- a/R/ResamplingSameOtherSizesCV.R
+++ b/R/ResamplingSameOtherSizesCV.R
@@ -25,10 +25,9 @@ ResamplingSameOtherSizesCV = R6::R6Class(
         label = "Compare Same/Other and Sizes Cross-Validation",
         man = "ResamplingSameOtherSizesCV")
     },
-    instantiate = function(task) {
+    get_instance = function(task) {
       . <- test.subset <- same <- full <- other <- stratum <- group <- row_id <- fold <- groups <- prop <- iteration <- NULL
       ## Above to avoid CRAN NOTEs.
-      task = mlr3::assert_task(mlr3::as_task(task))
       reserved.names <- c(
         "row_id", "fold",
         "subset", "group",
@@ -170,14 +169,10 @@ ResamplingSameOtherSizesCV = R6::R6Class(
           }
         }
       }
-      self$instance <- list(
+      list(
         iteration.dt=rbindlist(
           iteration.dt.list
         )[, iteration := .I][])
-      self$task_hash = task$hash
-      self$task_nrow = task$nrow
-      self$task_row_hash = task$row_hash
-      invisible(self)
     }
   )
 )

--- a/R/ResamplingVariableSizeTrainCV.R
+++ b/R/ResamplingVariableSizeTrainCV.R
@@ -19,10 +19,9 @@ ResamplingVariableSizeTrainCV = R6::R6Class(
         label = "Cross-Validation with variable size train sets",
         man = "ResamplingVariableSizeTrainCV")
     },
-    instantiate = function(task) {
+    get_instance = function(task) {
       row_id <- fold <- prop <- . <- row_seed <- iteration <- train_min_size <- train_size <- train_size_i <- NULL
       ## Above to avoid CRAN NOTEs.
-      task = mlr3::assert_task(mlr3::as_task(task))
       strata <- if(is.null(task$strata)){
         data.table(N=task$nrow, row_id=list(seq_len(task$nrow)))
       }else task$strata
@@ -78,7 +77,7 @@ ResamplingVariableSizeTrainCV = R6::R6Class(
             test=list(test.index.vec))
         }
       }
-      self$instance <- list(
+      list(
         iteration.dt=rbindlist(
           iteration.dt.list
         )[
@@ -87,10 +86,6 @@ ResamplingVariableSizeTrainCV = R6::R6Class(
         , train_min_size := min(train_size), by=train_size_i
         ][],
         id.dt=folds)
-      self$task_hash = task$hash
-      self$task_nrow = task$nrow
-      self$task_row_hash = task$row_hash
-      invisible(self)
     }
   )
 )


### PR DESCRIPTION
Sub-classes now define get_instance which contains the logic which is specific to each sub-class.

@be-marc I think this design is preferable to the changes you suggested in #26 (avoid repetition in sub-classes by moving common logic to parent class). Do you agree? Can you please review and suggest improvements?

Thanks!