### PR TITLE
Fix vimeo links: remove /manage/ from video URLs

### DIFF
--- a/vignettes/Older_resamplers.Rmd
+++ b/vignettes/Older_resamplers.Rmd
@@ -648,7 +648,7 @@ make_person_subset(class.bench.score)
 if(require(animint2)){
   viz <- animint(
     title="SOAK algorithm: train/predict on subsets, classification",
-    video="https://vimeo.com/manage/videos/1053464329",
+    video="https://vimeo.com/1053464329",
     pred=ggplot()+
       ggtitle("Predictions for selected train/test split")+
       theme_animint(height=700, width=700, rowspan=2)+
@@ -1138,7 +1138,7 @@ if(require(animint2)){
         showSelected=c("algorithm","seed"),
         clickSelects="iteration",
         data=reg.bench.score),
-    video="https://vimeo.com/manage/videos/1053467310",
+    video="https://vimeo.com/1053467310",
     source="https://github.com/tdhock/mlr3resampling/blob/main/vignettes/Older_resamplers.Rmd")
 }
 if(FALSE){


### PR DESCRIPTION
This PR fixes animint/gallery#28

Removed `/manage/videos/` from two video URLs in `vignettes/Older_resamplers.Rmd`:
- Changed `https://vimeo.com/manage/videos/1053467310` to `https://vimeo.com/1053467310`
- Changed `https://vimeo.com/manage/videos/1053464329` to `https://vimeo.com/1053464329`