### PR TITLE
fix fold potential mismatch

### DIFF
--- a/R/ResamplingSameOtherSizesCV.R
+++ b/R/ResamplingSameOtherSizesCV.R
@@ -96,6 +96,18 @@ ResamplingSameOtherSizesCV = R6::R6Class(
       fcol <- task$col_roles$fold
       fold.dt <- if(length(fcol)==1){
         fold <- task$data(cols=fcol)[[fcol]]
+        if(length(acol)==1){
+          group.fold.dt <- unique(data.table(group=avec, fold))
+          if(any(group.fold.dt[, .N, by=group][["N"]] > 1L)){
+            stop("task$col_roles$fold must be constant within each group")
+          }
+        }
+        n.unique.folds <- length(unique(fold))
+        if(n.unique.folds != n.folds){
+          stop(sprintf(
+            "fold column has %s unique values, but param_set$values$folds is %s",
+            n.unique.folds, n.folds))
+        }
         data.table(group.row.dt, fold)
       }else{
         sample.dt <- group.row.dt[

--- a/R/ResamplingSameOtherSizesCV.R
+++ b/R/ResamplingSameOtherSizesCV.R
@@ -102,12 +102,6 @@ ResamplingSameOtherSizesCV = R6::R6Class(
             stop("task$col_roles$fold must be constant within each group")
           }
         }
-        n.unique.folds <- length(unique(fold))
-        if(n.unique.folds != n.folds){
-          stop(sprintf(
-            "fold column has %s unique values, but param_set$values$folds is %s",
-            n.unique.folds, n.folds))
-        }
         data.table(group.row.dt, fold)
       }else{
         sample.dt <- group.row.dt[

--- a/tests/testthat/test-CRAN.R
+++ b/tests/testthat/test-CRAN.R
@@ -925,15 +925,4 @@ test_that("fold role is checked", {
   expect_error({
     soak$instantiate(group.task)
   }, "task$col_roles$fold must be constant within each group", fixed=TRUE)
-  count.dt <- data.table(
-    x=1:9,
-    y=factor(rep(c("a", "b", "c"), each=3)),
-    Fold=rep(1:3, length.out=9))
-  count.task <- mlr3::TaskClassif$new("fold_count_bad", count.dt, target="y")
-  count.task$col_roles$feature <- "x"
-  count.task$col_roles$fold <- "Fold"
-  count.task$col_roles$stratum <- "y"
-  expect_error({
-    soak$instantiate(count.task)
-  }, "fold column has 3 unique values, but param_set$values$folds is 2", fixed=TRUE)
 })

--- a/tests/testthat/test-CRAN.R
+++ b/tests/testthat/test-CRAN.R
@@ -908,3 +908,32 @@ test_that("fold and stratum roles work for reproducibility", {
   tlist <- mlr3resampling::proj_test(proj_dir)
   expect_identical(names(tlist), c("grid_jobs.csv", "results.csv"))
 })
+
+test_that("fold role is checked", {
+  soak <- mlr3resampling::ResamplingSameOtherSizesCV$new()
+  soak$param_set$values$folds <- 2L
+  group.dt <- data.table(
+    x=1:6,
+    y=factor(rep(c("a", "b"), each=3)),
+    grp=c(1, 1, 2, 2, 3, 3),
+    Fold=c(1, 2, 1, 1, 2, 2))
+  group.task <- mlr3::TaskClassif$new("group_fold_bad", group.dt, target="y")
+  group.task$col_roles$feature <- "x"
+  group.task$col_roles$group <- "grp"
+  group.task$col_roles$fold <- "Fold"
+  group.task$col_roles$stratum <- "y"
+  expect_error({
+    soak$instantiate(group.task)
+  }, "task$col_roles$fold must be constant within each group", fixed=TRUE)
+  count.dt <- data.table(
+    x=1:9,
+    y=factor(rep(c("a", "b", "c"), each=3)),
+    Fold=rep(1:3, length.out=9))
+  count.task <- mlr3::TaskClassif$new("fold_count_bad", count.dt, target="y")
+  count.task$col_roles$feature <- "x"
+  count.task$col_roles$fold <- "Fold"
+  count.task$col_roles$stratum <- "y"
+  expect_error({
+    soak$instantiate(count.task)
+  }, "fold column has 3 unique values, but param_set$values$folds is 2", fixed=TRUE)
+})


### PR DESCRIPTION
`ResamplingSameOtherSizesCV` currently accepts invalid supplied fold metadata. 
It does not reject cases where `task$col_roles$fold` varies within a `group`
it does not verify that the number of unique fold values matches `param_set$values$folds`. 
I have committed test cases in test-CRAN.R which reproduces both issues against the old implementation, so I think these validations should live in `.get_instance()` when `task$col_roles$fold `is provided.