### PR TITLE
sizes=0 means 5 train sizes per test subset

### DIFF
--- a/R/ResamplingSameOtherSizesCV.R
+++ b/R/ResamplingSameOtherSizesCV.R
@@ -129,13 +129,15 @@ ResamplingSameOtherSizesCV = R6::R6Class(
         tta.row <- train.test.groups[tta.i]
         op.chr <- if(self$param_set$values$sizes <= 0)"==" else ">="
         on.vec <- c("test.subset", paste("groups",op.chr,"train_groups"))
-        n.train.groups.vec <- c(tta.row[
+        n.train.groups.vec <- unique(c(
+          tta.row[
           train.size.dt,
           groups,
           on=on.vec,
           nomatch=0L],
-          if(self$param_set$values$sizes == 0)train.size.dt[
-            tta.row, min(train_groups), on="test.subset"])
+          if(self$param_set$values$sizes == 0) train.size.dt[
+            tta.row, min(train_groups), on="test.subset"]
+        ))
         for(seed in 1:self$param_set$values$seeds){
           is.set.subset <- list(
             test=fold.dt[["test.subset"]] == tta.row[["test.subset"]])

--- a/R/ResamplingSameOtherSizesCV.R
+++ b/R/ResamplingSameOtherSizesCV.R
@@ -127,13 +127,15 @@ ResamplingSameOtherSizesCV = R6::R6Class(
       iteration.dt.list <- list()
       for(tta.i in 1:nrow(train.test.groups)){
         tta.row <- train.test.groups[tta.i]
-        op.chr <- if(self$param_set$values$sizes == -1)"==" else ">="
+        op.chr <- if(self$param_set$values$sizes <= 0)"==" else ">="
         on.vec <- c("test.subset", paste("groups",op.chr,"train_groups"))
-        n.train.groups.vec <- tta.row[
+        n.train.groups.vec <- c(tta.row[
           train.size.dt,
           groups,
           on=on.vec,
-          nomatch=0L]
+          nomatch=0L],
+          if(self$param_set$values$sizes == 0)train.size.dt[
+            tta.row, min(train_groups), on="test.subset"])
         for(seed in 1:self$param_set$values$seeds){
           is.set.subset <- list(
             test=fold.dt[["test.subset"]] == tta.row[["test.subset"]])

--- a/tests/testthat/test-CRAN.R
+++ b/tests/testthat/test-CRAN.R
@@ -372,28 +372,20 @@ test_that("ResamplingSameOtherSizesCV yes subset, yes group, yes stratum, sizes=
   reg.task$col_roles$subset <- "random_group"
   n.subsets <- length(unique(task.dt$random_group))
   same_other_sizes_cv <- mlr3resampling::ResamplingSameOtherSizesCV$new()
-  n.folds <- 3
-  same_other_sizes_cv$param_set$values$folds <- n.folds
+  same_other_sizes_cv$param_set$values$folds <- 3
   same_other_sizes_cv$param_set$values$seeds <- 1
-  same_other_sizes_cv$param_set$values$ratio <- 0.5
   same_other_sizes_cv$param_set$values$sizes <- 0
   same_other_sizes_cv$param_set$values$ignore_subset <- FALSE
   same_other_sizes_cv$instantiate(reg.task)
-  computed <- same_other_sizes_cv$instance$iteration.dt
-  n.train.per.test <- 5
-  expect_equal(nrow(computed), n.folds*n.subsets*n.train.per.test)
-  one_fold <- computed[
-    test.fold == 1 & seed == 1 & test.subset == "A",
+  computed <- same_other_sizes_cv$instance$iteration.dt[
+    test.fold == 1 & test.subset == "A",
     .(train.subsets, groups, n.train.groups)
   ][order(train.subsets, n.train.groups)]
-  expect_identical(
-    one_fold,
-    data.table(
-      train.subsets = c("all", "all", "other", "other", "same"),
-      groups = c(700L, 700L, 600L, 600L, 100L),
-      n.train.groups = c(100L, 700L, 100L, 600L, 100L)
-    )
-  )
+  expected <- data.table(
+    train.subsets = c("all", "all", "other", "other", "same"),
+    groups = c(700L, 700L, 600L, 600L, 100L),
+    n.train.groups = c(100L, 700L, 100L, 600L, 100L))
+  expect_identical(computed, expected)
 })
 
 test_that("ResamplingSameOtherSizesCV yes subset, yes group, yes stratum, sizes=1", {

--- a/tests/testthat/test-CRAN.R
+++ b/tests/testthat/test-CRAN.R
@@ -362,6 +362,7 @@ test_that("ResamplingSameOtherSizesCV yes subset, yes group, yes stratum", {
   three.prop.list <- get_prop_mat(three[["train"]])
   expect_identical(three.prop.list, exp.prop.list)
 })
+
 test_that("ResamplingSameOtherSizesCV yes subset, yes group, yes stratum, sizes=0", {
   reg.task <- mlr3::TaskRegr$new(
     "sin", task.dt, target="y")
@@ -379,9 +380,11 @@ test_that("ResamplingSameOtherSizesCV yes subset, yes group, yes stratum, sizes=
   same_other_sizes_cv$param_set$values$ignore_subset <- FALSE
   same_other_sizes_cv$instantiate(reg.task)
   computed <- same_other_sizes_cv$instance$iteration.dt
-  n.train.per.test <- 6
+  computed[test.fold==1, .(test.subset, train.subsets, groups, n.train.groups)][order(test.subset)]
+  n.train.per.test <- 5
   expect_equal(nrow(computed), n.folds*n.subsets*n.train.per.test)
 })
+
 test_that("ResamplingSameOtherSizesCV yes subset, yes group, yes stratum, sizes=1", {
   reg.task <- mlr3::TaskRegr$new(
     "sin", task.dt, target="y")

--- a/tests/testthat/test-CRAN.R
+++ b/tests/testthat/test-CRAN.R
@@ -380,9 +380,20 @@ test_that("ResamplingSameOtherSizesCV yes subset, yes group, yes stratum, sizes=
   same_other_sizes_cv$param_set$values$ignore_subset <- FALSE
   same_other_sizes_cv$instantiate(reg.task)
   computed <- same_other_sizes_cv$instance$iteration.dt
-  computed[test.fold==1, .(test.subset, train.subsets, groups, n.train.groups)][order(test.subset)]
   n.train.per.test <- 5
   expect_equal(nrow(computed), n.folds*n.subsets*n.train.per.test)
+  one_fold <- computed[
+    test.fold == 1 & seed == 1 & test.subset == "A",
+    .(train.subsets, groups, n.train.groups)
+  ][order(train.subsets, n.train.groups)]
+  expect_identical(
+    one_fold,
+    data.table(
+      train.subsets = c("all", "all", "other", "other", "same"),
+      groups = c(700L, 700L, 600L, 600L, 100L),
+      n.train.groups = c(100L, 700L, 100L, 600L, 100L)
+    )
+  )
 })
 
 test_that("ResamplingSameOtherSizesCV yes subset, yes group, yes stratum, sizes=1", {


### PR DESCRIPTION
Closes #79 

this change makes SOAKED analysis more efficient, by avoiding computation of a train/test split (intermediate train set size between min and max) which is not used in pvalue_downsample().
@EngineerDanny can you please review?