### PR TITLE
fix pvalue and pvalue-downsample plot space at the top of the figure

### DIFF
--- a/R/pvalue.R
+++ b/R/pvalue.R
@@ -51,7 +51,7 @@ pvalue_compute <- function(
     score_value$Train_subsets,
     paste0(measure.vars, "-same")
   ))
-  label_order <- canonical_levels[canonical_levels %in% present_levels]
+  label_order <- c(canonical_levels[canonical_levels %in% present_levels], "")
   score_value[, Train_subsets := factor(Train_subsets, label_order)]
   score_wide <- dcast(
     score_value,

--- a/R/pvalue.R
+++ b/R/pvalue.R
@@ -51,7 +51,7 @@ pvalue_compute <- function(
     score_value$Train_subsets,
     paste0(measure.vars, "-same")
   ))
-  label_order <- c(canonical_levels[canonical_levels %in% present_levels], "")
+  label_order <- c(intersect(canonical_levels, present_levels), "")
   score_value[, Train_subsets := factor(Train_subsets, label_order)]
   score_wide <- dcast(
     score_value,

--- a/tests/testthat/test-CRAN.R
+++ b/tests/testthat/test-CRAN.R
@@ -507,6 +507,65 @@ test_that("hjust=0.5 for algo in middle", {
   expect_equal(plist$stats[algorithm=="conv" & Train_subsets=="same", hjust], 1)
 })
 
+test_that("plot.pvalue keeps blank top level", {
+  blank.top.levels <- c("all", "all-same", "same", "other-same", "other", "")
+  N <- 60L
+  task.dt <- data.table(
+    x=runif(N, -2, 2),
+    subset_col=factor(rep(c("A", "B"), each=N/2))
+  )[, y := x^2 + rnorm(.N, sd=0.2)][]
+  soak <- mlr3resampling::ResamplingSameOtherSizesCV$new()
+  reg.task <- mlr3::TaskRegr$new("toy_plot", task.dt, target="y")
+  reg.task$col_roles$feature <- "x"
+  reg.task$col_roles$subset <- "subset_col"
+  reg.task$col_roles$stratum <- "subset_col"
+  soak$param_set$values$folds <- 2L
+  soak$param_set$values$seeds <- 1L
+  soak$param_set$values$sizes <- 0L
+  bench.grid <- mlr3::benchmark_grid(
+    reg.task,
+    mlr3::LearnerRegrFeatureless$new(),
+    soak
+  )
+  bench.result <- mlr3::benchmark(bench.grid)
+  soak.score <- mlr3resampling::score(bench.result, mlr3::msr("regr.rmse"))
+  plist <- mlr3resampling::pvalue(soak.score)
+  expect_identical(
+    levels(plist$stats$Train_subsets),
+    blank.top.levels)
+})
+
+test_that("plot.pvalue_downsample keeps blank top level", {
+  blank.top.levels <- c("all", "all-same", "same", "other-same", "other", "")
+  N <- 60L
+  subset_name <- "Female cohort with long text"
+  task.dt <- data.table(
+    x=runif(N, -2, 2),
+    subset_col=factor(rep(c(subset_name, "Male cohort with long text"), each=N/2))
+  )[, y := x^2 + rnorm(.N, sd=0.2)][]
+  soak <- mlr3resampling::ResamplingSameOtherSizesCV$new()
+  reg.task <- mlr3::TaskRegr$new("toy_soak", task.dt, target="y")
+  reg.task$col_roles$feature <- "x"
+  reg.task$col_roles$subset <- "subset_col"
+  reg.task$col_roles$stratum <- "subset_col"
+  soak$param_set$values$folds <- 2L
+  soak$param_set$values$seeds <- 1L
+  soak$param_set$values$sizes <- 0L
+  bench.grid <- mlr3::benchmark_grid(
+    reg.task,
+    mlr3::LearnerRegrFeatureless$new(),
+    soak
+  )
+  bench.result <- mlr3::benchmark(bench.grid)
+  soak.score <- mlr3resampling::score(bench.result, mlr3::msr("regr.rmse"))
+  down.list <- mlr3resampling::pvalue_downsample(
+    soak.score[test.subset == subset_name]
+  )
+  expect_identical(
+    levels(down.list$stats$Train_subsets),
+    blank.top.levels)
+})
+
 test_that("regular K fold CV works in proj", {
   N <- 80
   set.seed(1)


### PR DESCRIPTION
Add the vertical space at the top of the figure.
Fix #76 

<img width="1200" height="525" alt="pvalue_downsample_tmp_plot" src="https://github.com/user-attachments/assets/3a9bb990-d455-497f-8a76-b245ba1010a9" />
