### PR TITLE
add train_seed arg for reproducibility with random learners

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,6 +70,7 @@ Suggests:
     lgr,
     future, future.apply,
     testthat,
+    WeightedROC,
     nc,
     rpart,
     directlabels,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mlr3resampling
 Type: Package
 Title: Resampling Algorithms for 'mlr3' Framework
-Version: 2026.4.13
+Version: 2026.4.15
 Encoding: UTF-8
 Authors@R: c(
     person("Toby", "Hocking",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Changes in version 2026.4.15 (PR#85)
+
+- proj_grid() gains argument train_seed, default=1L for reproducibility, use NA_integer_ for old behavior (seed not set before training).
+
 Changes in version 2026.4.13 (PR#83)
 
 - ResamplingSameOtherSizesCV with sizes=0 now means 5 train/test splits per test subset, instead of 6. The intermediate size was removed because it is not used in pvalue_downsample().

--- a/R/ResamplingSameOtherSizesCV.R
+++ b/R/ResamplingSameOtherSizesCV.R
@@ -28,7 +28,7 @@ ResamplingSameOtherSizesCV = R6::R6Class(
   ),
   private = list(
     .get_instance = function(task) {
-      . <- test.subset <- same <- full <- other <- stratum <- group <- row_id <- fold <- groups <- prop <- iteration <- NULL
+      . <- train_groups <- test.subset <- same <- full <- other <- stratum <- group <- row_id <- fold <- groups <- prop <- iteration <- NULL
       ## Above to avoid CRAN NOTEs.
       reserved.names <- c(
         "row_id", "fold",

--- a/R/proj.R
+++ b/R/proj.R
@@ -89,7 +89,7 @@ proj_fread <- function(proj_dir){
   out_list
 }  
 
-proj_grid <- function(proj_dir, tasks, learners, resamplings, order_jobs=NULL, score_args=NULL, save_learner=save_learner_default, save_pred=FALSE){
+proj_grid <- function(proj_dir, tasks, learners, resamplings, order_jobs=NULL, score_args=NULL, save_learner=save_learner_default, save_pred=FALSE, train_seed=1){
   . <- n.train.groups <- NULL
   ## Above to avoid CRAN NOTE.
   if(file.exists(proj_dir)){
@@ -198,6 +198,7 @@ proj_grid <- function(proj_dir, tasks, learners, resamplings, order_jobs=NULL, s
   proj.grid$tasks <- NULL
   saveRDS(proj.grid, file.path(proj_dir, "grid.rds"))
   out_dt <- only_atomic(ml_job_dt)
+  cat(train_seed, file=file.path(proj_dir, "train_seed"))
   fwrite(out_dt, file.path(proj_dir, "grid_jobs.csv"))
   if(basename(proj_dir)!="test")message(sprintf('grid with %d jobs created! Test one job with the following code in a new R session:\nmlr3resampling::proj_test("%s", max_jobs=1)', nrow(out_dt), normalizePath(proj_dir)))
   on.exit()
@@ -231,6 +232,8 @@ proj_compute <- function(grid_job_i, proj_dir, verbose=FALSE, process_fun=Sys.ge
   this.learner <- proj.grid$learners[[grid_job_row$learner.i]]
   resampling_list <- readRDS(grid_job_row[, file.path(
     proj_dir, "resamplings", task.i, resampling.i, paste0(iteration, ".rds"))])
+  train_seed <- scan(file.path(proj_dir, "train_seed"), quiet = TRUE)
+  set.seed(train_seed)
   this.learner$train(this.task, resampling_list$train)
   pred <- this.learner$predict(this.task, resampling_list$test)
   result.row <- data.table(

--- a/R/proj.R
+++ b/R/proj.R
@@ -89,7 +89,7 @@ proj_fread <- function(proj_dir){
   out_list
 }  
 
-proj_grid <- function(proj_dir, tasks, learners, resamplings, order_jobs=NULL, score_args=NULL, save_learner=save_learner_default, save_pred=FALSE, train_seed=1L){
+proj_grid <- function(proj_dir, tasks, learners, resamplings, order_jobs=NULL, score_args=NULL, save_learner=save_learner_default, save_pred=FALSE, train_seed=1L, resampling_seed=1L){
   . <- n.train.groups <- NULL
   ## Above to avoid CRAN NOTE.
   if(file.exists(proj_dir)){
@@ -135,6 +135,7 @@ proj_grid <- function(proj_dir, tasks, learners, resamplings, order_jobs=NULL, s
     saveRDS(task.obj, task.rds)
     for(resampling.i in seq_along(proj.grid$resamplings)){
       resampling.obj <- proj.grid$resamplings[[resampling.i]]$clone()
+      set.seed(resampling_seed)
       resampling.obj$instantiate(task.obj)
       iteration <- resampling.obj$instance$iteration.dt
       if(is.null(iteration)){

--- a/R/proj.R
+++ b/R/proj.R
@@ -89,12 +89,13 @@ proj_fread <- function(proj_dir){
   out_list
 }  
 
-proj_grid <- function(proj_dir, tasks, learners, resamplings, order_jobs=NULL, score_args=NULL, save_learner=save_learner_default, save_pred=FALSE, train_seed=1){
+proj_grid <- function(proj_dir, tasks, learners, resamplings, order_jobs=NULL, score_args=NULL, save_learner=save_learner_default, save_pred=FALSE, train_seed=1L){
   . <- n.train.groups <- NULL
   ## Above to avoid CRAN NOTE.
   if(file.exists(proj_dir)){
     stop(proj_dir, " already exists, so not over-writing")
   }
+  if(!is.integer(train_seed))stop("train_seed must be integer")
   dir.create(proj_dir, showWarnings = FALSE)
   on.exit(unlink(proj_dir, recursive=TRUE))
   if(is.null(score_args) && isFALSE(save_pred)){
@@ -196,9 +197,9 @@ proj_grid <- function(proj_dir, tasks, learners, resamplings, order_jobs=NULL, s
   task.i.max <- max(ml_job_dt$task.i)
   proj.grid$tasks <- proj.grid$tasks[seq(1, task.i.max)]
   proj.grid$tasks <- NULL
+  proj.grid$train_seed <- train_seed
   saveRDS(proj.grid, file.path(proj_dir, "grid.rds"))
   out_dt <- only_atomic(ml_job_dt)
-  cat(train_seed, file=file.path(proj_dir, "train_seed"))
   fwrite(out_dt, file.path(proj_dir, "grid_jobs.csv"))
   if(basename(proj_dir)!="test")message(sprintf('grid with %d jobs created! Test one job with the following code in a new R session:\nmlr3resampling::proj_test("%s", max_jobs=1)', nrow(out_dt), normalizePath(proj_dir)))
   on.exit()
@@ -232,8 +233,8 @@ proj_compute <- function(grid_job_i, proj_dir, verbose=FALSE, process_fun=Sys.ge
   this.learner <- proj.grid$learners[[grid_job_row$learner.i]]
   resampling_list <- readRDS(grid_job_row[, file.path(
     proj_dir, "resamplings", task.i, resampling.i, paste0(iteration, ".rds"))])
-  train_seed <- scan(file.path(proj_dir, "train_seed"), quiet = TRUE)
-  set.seed(train_seed)
+  train_seed <- proj.grid$train_seed
+  if(!is.na(train_seed))set.seed(train_seed)
   this.learner$train(this.task, resampling_list$train)
   pred <- this.learner$predict(this.task, resampling_list$test)
   result.row <- data.table(

--- a/man/proj_grid.Rd
+++ b/man/proj_grid.Rd
@@ -12,7 +12,8 @@
 proj_grid(
   proj_dir, tasks, learners, resamplings,
   order_jobs = NULL, score_args = NULL,
-  save_learner = save_learner_default, save_pred = FALSE)
+  save_learner = save_learner_default, save_pred = FALSE,
+  train_seed = 1L)
 }
 \arguments{
   \item{proj_dir}{Path to directory to create.}
@@ -39,6 +40,8 @@ proj_grid(
     Default \code{FALSE} means to not keep it (always returns
     \code{NULL}).
     \code{TRUE} means to keep it without any special processing.}
+  \item{train_seed}{integer: random seed to use before training (default
+    \code{1L} for reproducibility, or \code{NA_integer_} to not set seed.}
 }
 \details{
   This is Step 1 out of the

--- a/man/proj_grid.Rd
+++ b/man/proj_grid.Rd
@@ -41,7 +41,10 @@ proj_grid(
     \code{NULL}).
     \code{TRUE} means to keep it without any special processing.}
   \item{train_seed}{integer: random seed to use before training (default
-    \code{1L} for reproducibility, or \code{NA_integer_} to not set seed.}
+    \code{1L} for reproducibility, or \code{NA_integer_} to not set
+    seed. Note that this seed only affects training of random learners;
+    random splits from instantiating resamplings are controlled by the
+    random seed which is set at the time of calling \code{proj_grid()}.}
 }
 \details{
   This is Step 1 out of the

--- a/man/proj_grid.Rd
+++ b/man/proj_grid.Rd
@@ -40,11 +40,11 @@ proj_grid(
     Default \code{FALSE} means to not keep it (always returns
     \code{NULL}).
     \code{TRUE} means to keep it without any special processing.}
-  \item{train_seed}{integer: random seed to use before training (default
+  \item{train_seed}{integer: random seed to set before training (default
     \code{1L} for reproducibility, or \code{NA_integer_} to not set
-    seed. Note that this seed only affects training of random learners;
-    random splits from instantiating resamplings are controlled by the
-    random seed which is set at the time of calling \code{proj_grid()}.}
+    seed.}
+  \item{resampling_seed}{integer: random seed to set before
+    instantiating each resampling (default \code{1L}).}
 }
 \details{
   This is Step 1 out of the

--- a/man/proj_grid.Rd
+++ b/man/proj_grid.Rd
@@ -13,7 +13,7 @@ proj_grid(
   proj_dir, tasks, learners, resamplings,
   order_jobs = NULL, score_args = NULL,
   save_learner = save_learner_default, save_pred = FALSE,
-  train_seed = 1L)
+  train_seed = 1L, resampling_seed = 1L)
 }
 \arguments{
   \item{proj_dir}{Path to directory to create.}

--- a/tests/testthat/test-CRAN.R
+++ b/tests/testthat/test-CRAN.R
@@ -1009,8 +1009,9 @@ test_that("cv.glmnet same result between two tests", {
   }
   kfold <- mlr3resampling::ResamplingSameOtherSizesCV$new()
   pdir <- if(interactive())"~/pdir" else tempfile()
-  unlink(pdir, recursive = TRUE)
   task_list <- list(spam, spam_with_fold)
+  ## test 1 default set train seed.
+  unlink(pdir, recursive = TRUE)
   mlr3resampling::proj_grid(pdir, task_list, L, kfold, score_args=mlr3::msrs("classif.auc"))
   set.seed(1)#needed to avoid spurious err in checks.
   test_res_list <- list()
@@ -1024,5 +1025,23 @@ test_that("cv.glmnet same result between two tests", {
   test_wide <- dcast(
     test_res, task_id + algorithm ~ run, value.var="classif.auc")
   test_wide[task_id=="spam_with_fold", expect_identical(run1, run2)]
-  test_wide[task_id=="spam", expect_false(identical(run1, run2))]
+  test_wide[task_id=="spam", expect_equal(sum(run1!=run2), 2)]
+  ## test 2 train_seed=NULL means do not set seed.
+  unlink(pdir, recursive = TRUE)
+  mlr3resampling::proj_grid(pdir, task_list, L, kfold, score_args=mlr3::msrs("classif.auc"), train_seed=NULL)
+  set.seed(1)#needed to avoid spurious err in checks.
+  test_res_list <- list()
+  for(run.num in 1:2){
+    tres <- mlr3resampling::proj_test(pdir, min_samples_per_stratum = 20)
+    test_res_list[[run.num]] <- data.table(
+      run=paste0("run", run.num), tres$results.csv)
+  }
+  test_res <- rbindlist(test_res_list)[
+  , algorithm := sub("classif.", "", learner_id)]
+  test_wide <- dcast(
+    test_res, task_id + algorithm ~ run, value.var="classif.auc")
+  is.deterministic <- test_wide[
+  , task_id=="spam_with_fold" & algorithm=="rpart"]
+  test_wide[is.deterministic, expect_identical(run1, run2)]
+  test_wide[!is.deterministic, expect_equal(sum(run1!=run2), 3)]
 })

--- a/tests/testthat/test-CRAN.R
+++ b/tests/testthat/test-CRAN.R
@@ -1024,4 +1024,5 @@ test_that("cv.glmnet same result between two tests", {
   test_wide <- dcast(
     test_res, task_id + algorithm ~ run, value.var="classif.auc")
   test_wide[task_id=="spam_with_fold", expect_identical(run1, run2)]
+  test_wide[task_id=="spam", expect_false(identical(run1, run2))]
 })

--- a/tests/testthat/test-CRAN.R
+++ b/tests/testthat/test-CRAN.R
@@ -1026,9 +1026,9 @@ test_that("cv.glmnet same result between two tests", {
     test_res, task_id + algorithm ~ run, value.var="classif.auc")
   test_wide[task_id=="spam_with_fold", expect_identical(run1, run2)]
   test_wide[task_id=="spam", expect_equal(sum(run1!=run2), 2)]
-  ## test 2 train_seed=NULL means do not set seed.
+  ## test 2 train_seed=NA means do not set seed.
   unlink(pdir, recursive = TRUE)
-  mlr3resampling::proj_grid(pdir, task_list, L, kfold, score_args=mlr3::msrs("classif.auc"), train_seed=NULL)
+  mlr3resampling::proj_grid(pdir, task_list, L, kfold, score_args=mlr3::msrs("classif.auc"), train_seed=NA_integer_)
   set.seed(1)#needed to avoid spurious err in checks.
   test_res_list <- list()
   for(run.num in 1:2){

--- a/tests/testthat/test-CRAN.R
+++ b/tests/testthat/test-CRAN.R
@@ -1024,8 +1024,7 @@ test_that("cv.glmnet same result between two tests", {
   , algorithm := sub("classif.", "", learner_id)]
   test_wide <- dcast(
     test_res, task_id + algorithm ~ run, value.var="classif.auc")
-  test_wide[task_id=="spam_with_fold", expect_identical(run1, run2)]
-  test_wide[task_id=="spam", expect_equal(sum(run1!=run2), 2)]
+  test_wide[, expect_identical(run1, run2)]
   ## test 2 train_seed=NA means do not set seed.
   unlink(pdir, recursive = TRUE)
   mlr3resampling::proj_grid(pdir, task_list, L, kfold, score_args=mlr3::msrs("classif.auc"), train_seed=NA_integer_)
@@ -1040,8 +1039,5 @@ test_that("cv.glmnet same result between two tests", {
   , algorithm := sub("classif.", "", learner_id)]
   test_wide <- dcast(
     test_res, task_id + algorithm ~ run, value.var="classif.auc")
-  is.deterministic <- test_wide[
-  , task_id=="spam_with_fold" & algorithm=="rpart"]
-  test_wide[is.deterministic, expect_identical(run1, run2)]
-  test_wide[!is.deterministic, expect_equal(sum(run1!=run2), 3)]
+  test_wide[, expect_identical(run1, run2)]
 })

--- a/tests/testthat/test-CRAN.R
+++ b/tests/testthat/test-CRAN.R
@@ -991,3 +991,37 @@ test_that("fold role is checked", {
     soak$instantiate(group.task)
   }, "task$col_roles$fold must be constant within each group", fixed=TRUE)
 })
+
+test_that("cv.glmnet same result between two tests", {
+  spam <- mlr3::tsk("spam")
+  spam$col_roles$stratum <- "type"
+  sdata <- data.table(spam$data(), Fold=rep(1:3, length.out = spam$nrow))
+  spam_with_fold <- mlr3::TaskClassif$new(
+    "spam_with_fold", sdata, target="type")
+  spam_with_fold$col_roles$stratum <- c("type","Fold")
+  spam_with_fold$col_roles$fold <- "Fold"
+  spam_with_fold$col_roles$feature <- spam$col_roles$feature
+  L <- list(
+    mlr3learners::LearnerClassifCVGlmnet$new(),
+    mlr3::LearnerClassifRpart$new())
+  for(learner.i in seq_along(L)){
+    L[[learner.i]]$predict_type <- "prob"
+  }
+  kfold <- mlr3resampling::ResamplingSameOtherSizesCV$new()
+  pdir <- if(interactive())"~/pdir" else tempfile()
+  unlink(pdir, recursive = TRUE)
+  task_list <- list(spam, spam_with_fold)
+  mlr3resampling::proj_grid(pdir, task_list, L, kfold, score_args=mlr3::msrs("classif.auc"))
+  set.seed(1)#needed to avoid spurious err in checks.
+  test_res_list <- list()
+  for(run.num in 1:2){
+    tres <- mlr3resampling::proj_test(pdir, min_samples_per_stratum = 20)
+    test_res_list[[run.num]] <- data.table(
+      run=paste0("run", run.num), tres$results.csv)
+  }
+  test_res <- rbindlist(test_res_list)[
+  , algorithm := sub("classif.", "", learner_id)]
+  test_wide <- dcast(
+    test_res, task_id + algorithm ~ run, value.var="classif.auc")
+  test_wide[task_id=="spam_with_fold", expect_identical(run1, run2)]
+})

--- a/tests/testthat/test-mlr3torch.R
+++ b/tests/testthat/test-mlr3torch.R
@@ -470,8 +470,7 @@ test_that("torch same result between two runs", {
   , algorithm := sub("classif.", "", learner_id)]
   test_wide <- dcast(
     test_res, task_id + algorithm ~ run, value.var="classif.auc")
-  test_wide[task_id=="spam_with_fold", expect_identical(run1, run2)]
-  test_wide[task_id=="spam", expect_equal(sum(run1!=run2), 4)]
+  test_wide[, expect_identical(run1, run2)]
   ## test 2 train_seed=NA means do not set seed.
   unlink(pdir, recursive = TRUE)
   mlr3resampling::proj_grid(pdir, task_list, L, kfold, score_args=mlr3::msrs("classif.auc"), train_seed=NA_integer_)
@@ -486,8 +485,5 @@ test_that("torch same result between two runs", {
   , algorithm := sub("classif.", "", learner_id)]
   test_wide <- dcast(
     test_res, task_id + algorithm ~ run, value.var="classif.auc")
-  is.deterministic <- test_wide[
-  , task_id=="spam_with_fold" & algorithm=="rpart"]
-  test_wide[is.deterministic, expect_identical(run1, run2)]
-  test_wide[!is.deterministic, expect_equal(sum(run1!=run2), 7)]
+  test_wide[, expect_identical(run1, run2)]
 })

--- a/tests/testthat/test-mlr3torch.R
+++ b/tests/testthat/test-mlr3torch.R
@@ -419,3 +419,75 @@ test_that("torch and glmnet testing and interpretation", {
   expect_equal(as.numeric(Class_tab), as.numeric(etab))
 })
 
+test_that("torch same result between two runs", {
+  spam <- mlr3::tsk("spam")
+  spam$col_roles$stratum <- "type"
+  sdata <- data.table(spam$data(), Fold=rep(1:3, length.out = spam$nrow))
+  spam_with_fold <- mlr3::TaskClassif$new(
+    "spam_with_fold", sdata, target="type")
+  spam_with_fold$col_roles$stratum <- c("type","Fold")
+  spam_with_fold$col_roles$fold <- "Fold"
+  spam_with_fold$col_roles$feature <- spam$col_roles$feature
+  gen_linear <- torch::nn_module(
+    "my_linear",
+    initialize = function(task) {
+      self$weight = torch::nn_linear(spam$n_features, 1)
+    },
+    forward = function(x) {
+      self$weight(x)
+    }
+  )
+  MLP <- mlr3torch::LearnerTorchMLP$new(task_type="classif")
+  MLP$param_set$set_values(epochs=0, batch_size=10)
+  L <- list(
+    MLP,
+    mlr3resampling::AutoTunerTorch_epochs$new(
+      "torch_linear",
+      module_generator=gen_linear,
+      max_epochs=3,
+      batch_size=10,
+      measure_list=mlr3::msrs("classif.auc")
+    ),
+    mlr3learners::LearnerClassifCVGlmnet$new(),
+    mlr3::LearnerClassifRpart$new())
+  for(learner.i in seq_along(L)){
+    L[[learner.i]]$predict_type <- "prob"
+  }
+  kfold <- mlr3resampling::ResamplingSameOtherSizesCV$new()
+  pdir <- if(interactive())"~/pdir" else tempfile()
+  task_list <- list(spam, spam_with_fold)
+  ## test 1 default set train seed.
+  unlink(pdir, recursive = TRUE)
+  mlr3resampling::proj_grid(pdir, task_list, L, kfold, score_args=mlr3::msrs("classif.auc"))
+  set.seed(2)#needed to avoid spurious err in checks.
+  test_res_list <- list()
+  for(run.num in 1:2){
+    tres <- mlr3resampling::proj_test(pdir, min_samples_per_stratum = 20)
+    test_res_list[[run.num]] <- data.table(
+      run=paste0("run", run.num), tres$results.csv)
+  }
+  test_res <- rbindlist(test_res_list)[
+  , algorithm := sub("classif.", "", learner_id)]
+  test_wide <- dcast(
+    test_res, task_id + algorithm ~ run, value.var="classif.auc")
+  test_wide[task_id=="spam_with_fold", expect_identical(run1, run2)]
+  test_wide[task_id=="spam", expect_equal(sum(run1!=run2), 4)]
+  ## test 2 train_seed=NA means do not set seed.
+  unlink(pdir, recursive = TRUE)
+  mlr3resampling::proj_grid(pdir, task_list, L, kfold, score_args=mlr3::msrs("classif.auc"), train_seed=NA_integer_)
+  set.seed(2)#needed to avoid spurious err in checks.
+  test_res_list <- list()
+  for(run.num in 1:2){
+    tres <- mlr3resampling::proj_test(pdir, min_samples_per_stratum = 20)
+    test_res_list[[run.num]] <- data.table(
+      run=paste0("run", run.num), tres$results.csv)
+  }
+  test_res <- rbindlist(test_res_list)[
+  , algorithm := sub("classif.", "", learner_id)]
+  test_wide <- dcast(
+    test_res, task_id + algorithm ~ run, value.var="classif.auc")
+  is.deterministic <- test_wide[
+  , task_id=="spam_with_fold" & algorithm=="rpart"]
+  test_wide[is.deterministic, expect_identical(run1, run2)]
+  test_wide[!is.deterministic, expect_equal(sum(run1!=run2), 7)]
+})

--- a/vignettes/Reproducibility.Rmd
+++ b/vignettes/Reproducibility.Rmd
@@ -191,6 +191,13 @@ rbind(
 The output above is a table with AUC values that are identical across packages used for computation.
 These data indicate that the proposed framework with `fold` column role enables reproducibility even if `mlr3resampling` is not used.
 
+If the seed is not obvious from the code, you can read it from the grid RDS file:
+
+```{r}
+grid.rds <- file.path(pdir, "grid.rds")
+readRDS(grid.rds)$train_seed
+```
+
 # Comparison with batchtools
 
 If you want consistent results between runs with batchtools, you need to set the seed argument when making the registry.
@@ -270,6 +277,18 @@ rbind(
 ```
 
 The DIY results above are consistent with the previous two runs, indicating that reproducibility is possible with batchtools as well.
+
+If the seed was not set in the batchtools code, you can read it from the registry RDS file:
+
+```{r}
+registry.rds <- file.path(reg_dir, "registry.rds")
+rbind(
+  code=batchtools.seed,
+  registry=readRDS(registry.rds)$seed)
+unlink(reg_dir, recursive = TRUE)
+batchtools::makeExperimentRegistry(reg_dir)
+readRDS(registry.rds)$seed
+```
 
 # Conclusion
 

--- a/vignettes/Reproducibility.Rmd
+++ b/vignettes/Reproducibility.Rmd
@@ -1,0 +1,201 @@
+---
+vignette: >
+  %\VignetteIndexEntry{Reproducible benchmarks}
+  %\VignetteEngine{litedown::vignette}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+litedown::reactor(
+  collapse = TRUE,
+  comment = "#>",
+  fig.width=10,
+  fig.height=6)
+data.table::setDTthreads(1)
+```
+
+The goal of this vignette is to explain how to compute reproducible machine learning benchmarks.
+
+# Introduction
+
+Reproducibility is the ability to re-compute the exact same results, given the exact same inputs, possibly on a variety of different computers.
+
+In mlr3 benchmarks, there are three components, all of which may present barriers to reproducibility:
+
+* Tasks represent data sets, which may not have pre-defined splits or cross-validation folds, in which case mlr3 will create them randomly (with a loss of reproducibility).
+* Learners represent algorithms which may be deterministic (reproducible) or random (not reproducible unless random seed is set).
+* Resampling methods like cross-validation are inherently random.
+
+When using `mlr3resampling::proj_grid()`, the default is `train_seed=1L`, which means R’s random seed will be set before training.
+
+For reproducible train/test splits, we recommend
+
+* randomly creating a fold column, so that fold values respect strata such as class labels.
+* save data with the fold column as a new CSV file, which can be used to communicate to others what cross-validation splits you used in your benchmark.
+* assign the fold column to the `fold` role in the mlr3 Task.
+* use `mlr3resampling::ResamplingSameOtherSizesCV` which uses the column with `fold` role in cross-validation.
+
+These steps ensure that the benchmark results are reproducible, given the CSV file with fold column, and the random seed for training.
+
+# Example
+
+We begin by defining the Resampling method (default is 3-fold CV).
+
+```{r}
+kfold <- mlr3resampling::ResamplingSameOtherSizesCV$new()
+```
+
+Next we load the `spam` binary classification task, optionally down-sampling to 200 rows to make the computations quicker.
+
+```{r}
+spam <- mlr3::tsk("spam")
+## uncomment next line to speedup rendering:
+#spam$filter(as.integer(seq(1, spam$nrow, length.out = 200)))
+spam
+```
+
+Next, we create a new CSV file with fold IDs.
+
+```{r}
+library(data.table)
+spam_with_fold.csv <- if(interactive())"~/spam_with_fold.csv" else tempfile()
+spam_with_fold.dt <- spam$data()[
+, Fold := rep(1:3, length.out = .N)
+, by = type]
+fwrite(spam_with_fold.dt, spam_with_fold.csv)
+spam_with_fold.dt[, table(Fold, type)]
+```
+
+The outpat above shows that the number of samples in each class is approximately constant across folds.
+Next, we use these data to define a new task with the `fold` role.
+
+```{r}
+spam_with_fold <- mlr3::TaskClassif$new(
+  "spam_with_fold", spam_with_fold.dt, target="type")
+spam_with_fold$col_roles$fold <- "Fold"
+spam_with_fold$col_roles$feature <- spam$col_roles$feature
+```
+
+Below we assign the `stratum` role to both tasks, for proportional down-sampling.
+
+```{r}
+spam_with_fold$col_roles$stratum <- c("type","Fold")
+spam$col_roles$stratum <- "type"
+```
+
+Next we define learners and ensure their predict types are real-valued scores (`predict_type="prob"`), so we can compute AUC.
+
+```{r}
+learner_list <- list(
+  mlr3learners::LearnerClassifCVGlmnet$new(),
+  mlr3::LearnerClassifRpart$new())
+for(learner.i in seq_along(learner_list)){
+  learner_list[[learner.i]]$predict_type <- "prob"
+}
+```
+
+Next, we create a project grid.
+
+```{r}
+pdir <- if(interactive())"~/pdir" else tempfile()
+task_list <- list(spam, spam_with_fold)
+unlink(pdir, recursive = TRUE)
+measure_list <- mlr3::msrs("classif.auc")
+mlr3resampling::proj_grid(
+  pdir, task_list, learner_list, kfold, score_args=measure_list)
+```
+
+## Demonstration with test project
+
+Below we run `proj_test()` twice.
+
+```{r}
+test_res_list <- list()
+for(run.num in 1:2){
+  tres <- mlr3resampling::proj_test(pdir, min_samples_per_stratum = 20)
+  test_res_list[[run.num]] <- data.table(
+    run=paste0("run", run.num), tres$results.csv)
+}
+test_res <- rbindlist(test_res_list)[
+, algorithm := sub("classif.", "", learner_id)]
+dcast(
+  test_res, task_id + algorithm ~ run, value.var="classif.auc")
+```
+
+The result above shows that the two runs have the same AUC values only for `spam_with_fold`, not for `spam` (which gets a different fold vector for each run).
+
+## Demonstration with full benchmark
+
+Below we create two project grids from the same code.
+
+```{r}
+set.seed(1)
+jobs_list <- list()
+for(run.num in 1:2){
+  pdir <- if(interactive())paste0("~/pdir",run.num) else tempfile()
+  unlink(pdir, recursive = TRUE)
+  pgrid <- mlr3resampling::proj_grid(
+    pdir, task_list, learner_list, kfold, score_args=measure_list)
+  jobs_list[[run.num]] <- data.table(
+    run=paste0("run", run.num), pdir, job.i=pgrid[
+    , which(test.fold==1 & grepl("glmnet", learner_id))])
+}
+```
+
+In the code above, the two grids have different random fold assignments.
+Below, we compute one glmnet job for each run and task.
+
+```{r}
+proj_res <- rbindlist(jobs_list)[
+, mlr3resampling::proj_compute(job.i, pdir)
+, by=.(run, pdir, job.i)][
+, algorithm := sub("classif.", "", learner_id)]
+dcast(
+  proj_res, task_id + algorithm ~ run, value.var="classif.auc")
+```
+
+The results above are consistent with the results above.
+
+# Comparison with batchtools
+
+If you want consistent results between runs with batchtools, you need to set the seed argument when making the registry.
+
+```{r}
+(bgrid <- mlr3::benchmark_grid(task_list, learner_list, kfold))
+if(requireNamespace("mlr3batchmark")){
+  batch_dt_list <- list()
+  for(run.num in 1:2){
+    reg_dir <- if(interactive())paste0("~/reg",run.num) else tempfile()
+    unlink(reg_dir, recursive = TRUE)
+    reg <- batchtools::makeExperimentRegistry(reg_dir, seed=1)
+    mlr3batchmark::batchmark(bgrid)
+    jt <- batchtools::getJobTable()
+    jt1 <- jt[repl==1]
+    batchtools::submitJobs(jt1)
+    batchtools::waitForJobs()
+    ignore.learner <- function(L){
+      L$learner_state$model <- NULL
+      L
+    }
+    bt_res <- mlr3batchmark::reduceResultsBatchmark(jt1, fun=ignore.learner)
+    bt_score <- bt_res$score(measure_list)
+    batch_dt_list[[run.num]] <- data.table(
+      run=paste0("run", run.num), bt_score
+    )[
+    , algorithm := sub("classif.", "", learner_id)]
+  }
+  batch_dt <- rbindlist(batch_dt_list)
+  dcast(
+    batch_dt, task_id + algorithm ~ run, value.var="classif.auc")
+}
+```
+
+# Conclusion
+
+We see that reproducibility is possible in mlr3.
+Using `mlr3resampling::proj_grid()`
+
+* Use tasks with `fold` column role.
+* Default sets random seed for reproducible training.
+
+Using `mlr3batchmark`, user needs to give `seed=1` argument to `batchtools::makeExperimentRegistry`.

--- a/vignettes/Reproducibility.Rmd
+++ b/vignettes/Reproducibility.Rmd
@@ -122,7 +122,8 @@ dcast(
   test_res, task_id + algorithm ~ run, value.var="classif.auc")
 ```
 
-The result above shows that the two runs have the same AUC values only for `spam_with_fold`, not for `spam` (which gets a different fold vector for each run).
+The result above shows that the two runs have the same AUC values.
+Even for `spam`, which does not have `fold` column role, the random seed is set for reproducible fold assignments.
 
 ## Demonstration with full benchmark
 
@@ -142,7 +143,7 @@ for(run.num in 1:2){
 }
 ```
 
-In the code above, the two grids have different random fold assignments.
+In the code above, the two grids have the same fold assignments (because random seed is set inside `proj_grid`).
 Below, we compute one glmnet job for each run and task.
 
 ```{r}
@@ -154,7 +155,7 @@ dcast(
   proj_res, task_id + algorithm ~ run, value.var="classif.auc")
 ```
 
-The results here using `proj_compute()` are consistent with the results above using `proj_test()`: results are reproducible between runs if the Task has the `fold` role.
+The results here using `proj_compute()` are consistent with the results above using `proj_test()`: results are reproducible between runs.
 
 ## Do it yourself
 
@@ -189,7 +190,7 @@ rbind(
 ```
 
 The output above is a table with AUC values that are identical across packages used for computation.
-These data indicate that the proposed framework with `fold` column role enables reproducibility even if `mlr3resampling` is not used.
+These data indicate that the proposed framework enables reproducibility even if `mlr3resampling` is not used.
 
 If the seed is not obvious from the code, you can read it from the grid RDS file:
 
@@ -295,7 +296,7 @@ readRDS(registry.rds)$seed
 We see that reproducibility is possible in mlr3.
 Using `mlr3resampling::proj_grid()`
 
-* Use tasks with `fold` column role.
-* Default sets random seed for reproducible training.
+* For simple reproducibility even outside R and mlr3, use tasks with `fold` column role.
+* Even without `fold` column role, random seeds are set for reproducible splitting and training.
 
 Using `mlr3batchmark`, user needs to give `seed` argument to `batchtools::makeExperimentRegistry`.

--- a/vignettes/Reproducibility.Rmd
+++ b/vignettes/Reproducibility.Rmd
@@ -154,7 +154,42 @@ dcast(
   proj_res, task_id + algorithm ~ run, value.var="classif.auc")
 ```
 
-The results above are consistent with the results above.
+The results here using `proj_compute()` are consistent with the results above using `proj_test()`: results are reproducible between runs if the Task has the `fold` role.
+
+## Do it yourself
+
+In this section we demonstrate that it is possible to compute the same test AUC values without using the mlr3 framework.
+
+```{r}
+fold1.dt <- data.table(spam_with_fold.dt)[
+, set := ifelse(Fold==1, "test", "train")][]
+set.dt.list <- split(fold1.dt, fold1.dt$set)
+set.xy.list <- list()
+for(set in names(set.dt.list)){
+  set.dt <- set.dt.list[[set]]
+  set.xy.list[[set]] <- list(
+    X=as.matrix(set.dt[, spam$col_roles$feature, with=FALSE]),
+    y=set.dt$type)
+}
+library(glmnet)
+set.seed(1)
+cvg_train_predict <- function(set.xy.list){
+  cvfit <- with(set.xy.list$train, cv.glmnet(X, y, family="binomial"))
+  with(set.xy.list$test, {
+    pred <- predict(cvfit, X)
+    roc.df <- WeightedROC::WeightedROC(pred, y)
+    WeightedROC::WeightedAUC(roc.df)
+  })
+}
+fold1.test.auc <- cvg_train_predict(set.xy.list)
+rbind(
+  data.table(packages="glmnet,WeightedROC", run="only", auc=fold1.test.auc),
+  proj_res[task_id=="spam_with_fold", .(
+    packages="mlr3resampling", run, auc=classif.auc)])
+```
+
+The output above is a table with AUC values that are identical across packages used for computation.
+These data indicate that the proposed framework with `fold` column role enables reproducibility even if `mlr3resampling` is not used.
 
 # Comparison with batchtools
 
@@ -162,12 +197,13 @@ If you want consistent results between runs with batchtools, you need to set the
 
 ```{r}
 (bgrid <- mlr3::benchmark_grid(task_list, learner_list, kfold))
+batchtools.seed <- 1
 if(requireNamespace("mlr3batchmark")){
   batch_dt_list <- list()
   for(run.num in 1:2){
     reg_dir <- if(interactive())paste0("~/reg",run.num) else tempfile()
     unlink(reg_dir, recursive = TRUE)
-    reg <- batchtools::makeExperimentRegistry(reg_dir, seed=1)
+    reg <- batchtools::makeExperimentRegistry(reg_dir, seed=batchtools.seed)
     mlr3batchmark::batchmark(bgrid)
     jt <- batchtools::getJobTable()
     jt1 <- jt[repl==1]
@@ -190,6 +226,51 @@ if(requireNamespace("mlr3batchmark")){
 }
 ```
 
+The table above shows consistent results across runs, which means that reproducibility is possible as long as batchtools is used with the same seed argument.
+
+## Do it yourself
+
+It is possible to reproduce these results without batchtools.
+First, the code below shows that the `bgrid` object contains an instantiated sampler with fold IDs that are consistent with the values in the `Fold` column.
+
+```{r}
+bgrid_dt <- as.data.table(bgrid)[, task_id := sapply(task, "[[", "id")][]
+resampler_with_fold <- bgrid_dt[task_id=="spam_with_fold"]$resampling[[1]]
+identical(resampler_with_fold$instance$fold.dt$Fold, spam_with_fold.dt$Fold)
+```
+
+To reproduce these values outside of the batchtools framework, we need to set the same random seed that was used by batchtools.
+This is documented on `?batchtools::makeExperimentRegistry` which says
+
+```
+    seed: ['integer(1)']
+          Start seed for jobs. Each job uses the ('seed' + 'job.id') as
+          seed. Default is a random integer between 1 and 32768.
+```
+
+The code below sets this random seed.
+
+```{r}
+(one_job <- jt1[, let(
+  task_id = sapply(prob.pars, "[[", "task_id"),
+  learner_id = sapply(algo.pars, "[[", "learner_id")
+)][task_id=="spam_with_fold" & learner_id=="classif.cv_glmnet"])
+set.seed(one_job$job.id+batchtools.seed)
+```
+
+Next we train cv glmnet again.
+
+```{r}
+batchtools.test.auc <- cvg_train_predict(set.xy.list)
+rbind(
+  data.table(
+    packages="glmnet,WeightedROC", run="only", auc=batchtools.test.auc),
+  batch_dt[algorithm=="cv_glmnet" & task_id=="spam_with_fold", .(
+    packages="batchtools", run, auc=classif.auc)])
+```
+
+The DIY results above are consistent with the previous two runs, indicating that reproducibility is possible with batchtools as well.
+
 # Conclusion
 
 We see that reproducibility is possible in mlr3.
@@ -198,4 +279,4 @@ Using `mlr3resampling::proj_grid()`
 * Use tasks with `fold` column role.
 * Default sets random seed for reproducible training.
 
-Using `mlr3batchmark`, user needs to give `seed=1` argument to `batchtools::makeExperimentRegistry`.
+Using `mlr3batchmark`, user needs to give `seed` argument to `batchtools::makeExperimentRegistry`.


### PR DESCRIPTION
https://85-merge--mlr3resampling.netlify.app/doc/reproducibility

in benchmarks, currently we can control resampling randomness by adding fold role to task.

but in benchmarks we can’t control random learners like glmnet https://github.com/mlr-org/mlr3learners/pull/382

added a test that demonstrates this (and in which we can see same result between runs for deterministic rpart).
```r
> test_wide
          task_id algorithm      run1      run2
1:           spam cv_glmnet 0.5000000 0.9000000
2:           spam     rpart 0.5928571 0.7785714
3: spam_with_fold cv_glmnet 0.9600000 0.9475000
4: spam_with_fold     rpart 0.9200000 0.9200000
```
TODO add seed param to proj_grid.