### PR TITLE
add downsample vignette

### DIFF
--- a/vignettes/downsampling_group_stratum.Rmd
+++ b/vignettes/downsampling_group_stratum.Rmd
@@ -1,0 +1,153 @@
+---
+vignette: >
+  %\VignetteIndexEntry{Downsampling with group and stratum}
+  %\VignetteEngine{litedown::vignette}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+litedown::reactor(
+  print=NA,
+  collapse = TRUE,
+  comment = "#>",
+  fig.width=10,
+  fig.height=6)
+data.table::setDTthreads(1)
+```
+
+In `mlr3`, a data set is represented as a `Task` with meta-data called roles which define how columns should be used for learning and evaluation.
+The goal of this vignette is to explain how downsampling respects `group` and `stratum` roles.
+
+# Introduction: role definitions
+
+Previous column roles in `mlr3` are:
+
+* `stratum`: proportions should be respected when splitting.
+* `group`: rows that must stay together when splitting.
+
+# Example using AZtrees data
+
+The `AZtrees` data represent an image segmentation problem.
+Each row is a pixel, which we want to classify as tree or not (`stratum` role).
+Data were labeled by drawing polygons on a map (`group` role).
+Data are divided into either 3 or 4 regions (`subset` role).
+
+```{r}
+data(AZtrees, package="mlr3resampling")
+library(data.table)
+options(datatable.print.keys=FALSE, datatable.print.class=FALSE)
+AZtrees[, .(polygon, y)]
+```
+
+Above we see the two columns that are relevant for these roles in these data.
+Below we count the number of rows for each polygon,
+
+```{r}
+dcast(AZtrees, polygon ~ y, length)[order(`Not tree`, -Tree)]
+```
+
+Above we see that there are several big polygons with no trees (hundreds of rows), whereas the polygons for presence of trees are smaller (max 45 rows).
+Below we define a helper function which creates a `Task` and assigns roles based on arguments.
+
+```{r}
+trees <- function(..., folds=3L){
+  trees_task <- mlr3::as_task_classif(AZtrees, target="y")
+  role_list <- list(...)
+  for(role in names(role_list)){
+    trees_task$col_roles[[role]] <- role_list[[role]]
+  }
+  cv <- mlr3resampling::ResamplingSameOtherSizesCV$new()
+  cv$param_set$values$folds <- folds
+  cv$param_set$values$sizes <- 1
+  cv$instantiate(trees_task)
+  role_dt <- AZtrees[, .(y, polygon, set="ignored")]
+  result_list <- list()
+  for(it in 1:cv$iters){
+    train_dt <- data.table(role_dt)[
+      cv$train_set(it), set := "train"
+    ][
+      cv$test_set(it), set := "test"
+    ][set!="test"]
+    if("ignored" %in% train_dt$set){
+      in_list <- list(
+        rows=train_dt,
+        groups=train_dt[, .(set=paste(unique(set), collapse=",")), by=.(y,polygon)])
+      out_list <- list()
+      for(unit in names(in_list)){
+        in_dt <- in_list[[unit]]
+        out_list[[unit]] <- rbind(in_dt[, table(y, set)], TOTAL=in_dt[, table(set)])
+      }
+      result_list[[length(result_list)+1]] <- out_list
+    }
+  }
+  result_list
+}
+set.seed(1)
+```
+
+Above we set the seed to obtain reproducible results below (fold assignment is random).
+
+## Cross-validation with no column roles
+
+Below we show counts of rows and groups in each fold, when no column roles are set:
+
+```{r}
+trees()
+```
+
+We see in above that 
+
+* in `rows`, there is about the same label distribution per fold (plus or minus 10 or 20 labels across folds), but not exactly the same (this can be achieved by setting `stratum` role). In `TOTAL` row we see the same number of rows per fold (plus or minus 1 because the total number of rows has a remainder when divided into the number of folds).
+* in `groups`, rows from some polygons have been split into several different folds (`1,2` etc.), which is undesirable (and can be avoided by setting `group` role).
+
+## Cross-validation using strata
+
+Next, we illustrate the `stratum` column role.
+
+```{r}
+trees(stratum="y")
+```
+
+Above we see that
+
+* in `rows`, both the label counts, and the `TOTAL`, are consistent across folds (plus or minus 1).
+* in `groups`, there is large variation across folds, and some polygons have been split into different folds (column named `1,2` etc.).
+
+## Cross-validation on polygons
+
+Below we compute counts when setting `group` role to `polygon`:
+
+```{r}
+trees(group="polygon")
+```
+
+Above we see 
+
+* in `rows`, there is substantial label distribution variation across folds (which can be avoided by setting `stratum` role). We see the `TOTAL` number of rows is equal across folds (again plus or minus 1).
+* in `groups`, each polygon has been assigned to one fold (no `1,2` etc.), which is desirable. We see different numbers of `TOTAL` groups per fold, which is expected, because the algorithm attempts to equalize number or rows per fold, and there are different numbers or rows per group.
+
+## Cross-validation on polygons with strata
+
+Below we compute counts when setting `stratum` and `group` roles.
+
+```{r}
+trees(stratum="y", group="polygon")
+```
+
+Above we see
+
+* in `rows`, the labels counts and `TOTAL` are consistent across folds (again plus or minus 1).
+* in `groups`, each polygon has been assigned to one fold (no `1,2` etc.), which is desirable. We see different numbers of `TOTAL` groups per fold, which is expected, because the algorithm attempts to equalize number or rows per fold, and there are different numbers or rows per group.
+
+# Example using respiratory data
+
+These are medical data,
+
+* with a binary target `outcome` (values 0 or 1),
+* person `id` used for group.
+
+TODO
+
+# Conclusion
+
+Overall these results show that the proposed resampling methods can handle complex cross-validation experiments, including downsampling with `group` and `stratum` roles.

--- a/vignettes/downsampling_group_stratum.Rmd
+++ b/vignettes/downsampling_group_stratum.Rmd
@@ -98,7 +98,7 @@ trees()
 We see in above that 
 
 * in `rows`, there is about the same label distribution per fold (plus or minus 10 or 20 labels across folds), but not exactly the same (this can be achieved by setting `stratum` role). In `TOTAL` row we see the same number of rows per fold (plus or minus 1 because the total number of rows has a remainder when divided into the number of folds).
-* in `groups`, rows from some polygons have been split into several different folds (`1,2` etc.), which is undesirable (and can be avoided by setting `group` role).
+* in `groups`, rows from some polygons have been split into several different folds (`ignored,train` etc.), which is undesirable (and can be avoided by setting `group` role).
 
 ## Cross-validation using strata
 
@@ -111,7 +111,7 @@ trees(stratum="y")
 Above we see that
 
 * in `rows`, both the label counts, and the `TOTAL`, are consistent across folds (plus or minus 1).
-* in `groups`, there is large variation across folds, and some polygons have been split into different folds (column named `1,2` etc.).
+* in `groups`, there is large variation across folds, and some polygons have been split into different folds (column named `ignored,train` etc.).
 
 ## Cross-validation on polygons
 
@@ -124,7 +124,7 @@ trees(group="polygon")
 Above we see 
 
 * in `rows`, there is substantial label distribution variation across folds (which can be avoided by setting `stratum` role). We see the `TOTAL` number of rows is equal across folds (again plus or minus 1).
-* in `groups`, each polygon has been assigned to one fold (no `1,2` etc.), which is desirable. We see different numbers of `TOTAL` groups per fold, which is expected, because the algorithm attempts to equalize number or rows per fold, and there are different numbers or rows per group.
+* in `groups`, each polygon has been assigned to one fold (no `ignored,train` etc.), which is desirable. We see different numbers of `TOTAL` groups per fold, which is expected, because the algorithm attempts to equalize number or rows per fold, and there are different numbers or rows per group.
 
 ## Cross-validation on polygons with strata
 
@@ -136,7 +136,7 @@ trees(stratum="y", group="polygon")
 
 Above we see
 
-* in `rows`, the labels counts and `TOTAL` are consistent across folds (again plus or minus 1).
+* in `rows`, the labels counts and `TOTAL` are consistent across folds (again plus or minus 1). TODO this is not true, need to fix code.
 * in `groups`, each polygon has been assigned to one fold (no `1,2` etc.), which is desirable. We see different numbers of `TOTAL` groups per fold, which is expected, because the algorithm attempts to equalize number or rows per fold, and there are different numbers or rows per group.
 
 # Example using respiratory data


### PR DESCRIPTION
this vignette shows an issue with the current downsampling code.

proportions are ok with strata, but group is not respected: (expected)
```r
> trees(stratum="y")
[[1]]
[[1]]$rows
         ignored train
Not tree    1761  1760
Tree         225   224
TOTAL       1986  1984

[[1]]$groups
         ignored ignored,train train train,ignored
Not tree       2            34     1            31
Tree          25            34    19            25
TOTAL         27            68    20            56
```

TOTAL number of polygons is respected when group is set, but strata proportions are not: (expected)
```r
> trees(group="polygon")
[[1]]
[[1]]$rows
         ignored train
Not tree    2559   902
Tree         207   302
TOTAL       2766  1204

[[1]]$groups
         ignored train
Not tree      31    18
Tree          35    47
TOTAL         66    65
```

Same result (not expected) when both strata and group is set:
```r
> trees(stratum="y", group="polygon")
[[1]]
[[1]]$rows
         ignored train
Not tree    1637  1884
Tree         210   239
TOTAL       1847  2123

[[1]]$groups
         ignored train
Not tree      27    26
Tree          39    39
TOTAL         66    65
```
in this last case, row strata counts should be equalized across train/ignored, but they are not.