### PR TITLE
test 6 5 ideal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mlr3resampling
 Type: Package
 Title: Resampling Algorithms for 'mlr3' Framework
-Version: 2026.6.12
+Version: 2026.6.28
 Encoding: UTF-8
 Authors@R: c(
     person("Toby", "Hocking",

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Changes in version 2026.6.28
+
+- Add test case for ResamplingSameOtherSizesCV, group_stratum_algo=RSS, which requires key/sort by neg_freq for tie-breaking.
+
 Changes in version 2026.6.12
 
 - plot.score() works with ResamplingCV, thanks to Zina Randria for reporting the issue.

--- a/R/ResamplingSameOtherSizesCV.R
+++ b/R/ResamplingSameOtherSizesCV.R
@@ -133,10 +133,10 @@ ResamplingSameOtherSizesCV = R6::R6Class(
           fold.dt[, let(
             rss = sum((table(stratum_fac)-ideal.tab)^2),
             neg_nrow = -.N,
-            freq = mean(ideal.tab*table(stratum_fac)),
+            neg_freq = -mean(ideal.tab*table(stratum_fac)),
             g_ord = min(random_order)
           ), by=group]
-          setkey(fold.dt, rss, neg_nrow, freq, g_ord)
+          setkey(fold.dt, rss, neg_nrow, neg_freq, g_ord)
         }
         fun <- get(paste0(
           "stratified_group_cv_",

--- a/tests/testthat/test-CRAN.R
+++ b/tests/testthat/test-CRAN.R
@@ -966,13 +966,24 @@ test_that("prop sizes for regular sized groups with multiple strata", {
   expect_equal(fpg.dt[algo=="RSS" & nfold==5, sort(N)], rep(c(3,27),each=10))
 })
 
-test_that("deterministic fold assignment for unique group sizes with multiple strata", {
-  files <- rbind(
-    data.table(g="f1g1", y=c(1,2)),
-    data.table(g="f1g2", y=c(2,2)),
-    data.table(g="f2g1", y=c(1,2,2)),
-    data.table(g="f2g2", y=c(2)),
-    data.table(g="f3g1", y=c(1,2,2,2)))
+gdt <- function(..., strata=2){
+  m <- matrix(c(...), ncol=strata, byrow=TRUE)
+  data.table(row.i=1:nrow(m))[, {
+    times <- m[row.i,]
+    y <- rep(1:strata, times)
+    p <- paste(times, collapse=",")
+    g <- paste0(row.i, "_", p)
+    data.table(g, y)
+  }, by=row.i]
+}
+
+test_that("deterministic optimal fold assignment for unique group sizes with multiple strata", {
+  files <- gdt(
+    1,1,
+    0,2,
+    1,2,
+    0,1,
+    1,3)
   ideal <- as.numeric(files[, table(y)]/3)
   files[, table(g, y)]
   comb.dt <- CJ(set_group=c(TRUE,FALSE), run=paste0("run", 1:2))
@@ -984,8 +995,10 @@ test_that("deterministic fold assignment for unique group sizes with multiple st
     task_amr$set_col_roles("y", roles = c("target", "stratum"))
     task_amr$col_roles
     test.validation.resampling = mlr3resampling::ResamplingSameOtherSizesCV$new()
+    test.validation.resampling$param_set$values$group_stratum_algo <- "RSS"
     test.validation.resampling$instantiate(task_amr)
     fold.dt <- test.validation.resampling$instance$fold.dt
+    fold.dt[, table(y, fold)]
     expect_equal(sum(fold.dt[, t(table(fold, stratum))]==ideal), 6)
     fpg <- fold.dt[, .(N=.N), by=.(fold, group)]
     fpg.dt.list[[comb.i]] <- data.table(comb, fpg)
@@ -998,23 +1011,46 @@ test_that("deterministic fold assignment for unique group sizes with multiple st
   folds[set_group==TRUE,  expect_identical(run1, run2)]
 })
 
-test_that("deterministic fold assignment for ties ideal 6 5", {
-  gid <- 0
-  g <- function(...){
-    times <- c(...)
-    y <- rep(1:2, times)
-    p <- paste(times, collapse=",")
-    gid <<- gid+1
-    g <- paste0(p, "_", gid)
-    data.table(g, y)
+test_that("compare assignment for five unique group sizes with multiple strata", {
+  files <- gdt(
+    1,1,
+    0,2,
+    1,2,
+    0,1,
+    1,3)
+  ideal <- as.numeric(files[, table(y)]/3)
+  files[, table(g, y)]
+  tab.list <- list()
+  for(group_stratum_algo in c("Wasikowski","RSS")){
+    set.seed(1)
+    task_amr = mlr3::as_task_classif(files, target = "y")
+    task_amr$set_col_roles("g", roles = "group")
+    task_amr$set_col_roles("y", roles = c("target", "stratum"))
+    test.validation.resampling = mlr3resampling::ResamplingSameOtherSizesCV$new()
+    test.validation.resampling$param_set$values$group_stratum_algo <- group_stratum_algo
+    test.validation.resampling$instantiate(task_amr)
+    fold.dt <- test.validation.resampling$instance$fold.dt[
+    , var := var(table(y))
+    , by=group][]
+    group.dt <- fold.dt[, .SD[1], by=group][, counts := sub(".*_", "", group)]
+    print(if("rss" %in% names(fold.dt))group.dt[
+      order(rss), .(counts, fold, rss)
+    ] else group.dt[
+      order(neg_sd, g_ord),  .(counts, fold, var=neg_sd^2, g_ord)])
+    print(tab.list[[group_stratum_algo]] <- fold.dt[, table(y, fold)])
   }
-  files <- rbind(
-    g(5,3),
-    g(3,0),
-    g(1,2),
-    g(1,2),
-    g(1,2),
-    g(1,1))
+  expect_equal(sort(tab.list$Wasikowski), c(1,1,1,2,3,4))
+  expect_equal(sort(tab.list$RSS), c(1,1,1,3,3,3))
+})
+
+test_that("deterministic fold assignment for ties ideal 6 5", {
+  files <- gdt(
+    5,3,
+    3,0,
+    1,2,
+    1,2,
+    1,2,
+    1,1)
   files[, table(y)]
   task_amr = mlr3::as_task_classif(files, target = "y")
   task_amr$set_col_roles("g", roles = "group")
@@ -1023,6 +1059,13 @@ test_that("deterministic fold assignment for ties ideal 6 5", {
   test.validation.resampling$param_set$values$folds <- 2
   test.validation.resampling$instantiate(task_amr)
   fold.dt <- test.validation.resampling$instance$fold.dt
+  fold.dt[
+  , sd := sd(table(y))
+  , by=group][
+  , .SD[1]
+  , by=group][, .(
+    counts=sub(".*_", "", group),
+    sd, rss, nrow=-neg_nrow, freq=-neg_freq)]
   stab <- sort(fold.dt[, table(stratum, fold)])
   expect_equal(stab, c(5,5,6,6))
   for(fsign in c(-1, 1)){
@@ -1037,7 +1080,13 @@ test_that("deterministic fold assignment for ties ideal 6 5", {
       , paste0("f", f, "s", 1:2) := lapply(.SD, function(x)cumsum(ifelse(fold.out==f, x, 0)))
       , .SDcols=paste0("s", 1:2)][]
     }
-    print(fwide)
+    p <- function(...)apply(cbind(...), 1, paste, collapse=",")
+    print(fwide[, .(
+      group=p(s1,s2),
+      fold=fold.out,
+      fold1=p(f1s1,f1s2),
+      fold2=p(f2s1,f2s2)
+    )])
     print(table(fold.ord$stratum, fold.out))
   }
 })

--- a/tests/testthat/test-CRAN.R
+++ b/tests/testthat/test-CRAN.R
@@ -998,6 +998,50 @@ test_that("deterministic fold assignment for unique group sizes with multiple st
   folds[set_group==TRUE,  expect_identical(run1, run2)]
 })
 
+test_that("deterministic fold assignment for ties ideal 6 5", {
+  gid <- 0
+  g <- function(...){
+    times <- c(...)
+    y <- rep(1:2, times)
+    p <- paste(times, collapse=",")
+    gid <<- gid+1
+    g <- paste0(p, "_", gid)
+    data.table(g, y)
+  }
+  files <- rbind(
+    g(5,3),
+    g(3,0),
+    g(1,2),
+    g(1,2),
+    g(1,2),
+    g(1,1))
+  files[, table(y)]
+  task_amr = mlr3::as_task_classif(files, target = "y")
+  task_amr$set_col_roles("g", roles = "group")
+  task_amr$set_col_roles("y", roles = c("target", "stratum"))
+  test.validation.resampling = mlr3resampling::ResamplingSameOtherSizesCV$new()
+  test.validation.resampling$param_set$values$folds <- 2
+  test.validation.resampling$instantiate(task_amr)
+  fold.dt <- test.validation.resampling$instance$fold.dt
+  stab <- sort(fold.dt[, table(stratum, fold)])
+  expect_equal(stab, c(5,5,6,6))
+  for(fsign in c(-1, 1)){
+    fold.ord <- fold.dt[order(rss, neg_nrow, fsign*neg_freq)][, let(
+      g.int = as.integer(factor(group, unique(group))),
+      Stratum = paste0("s", stratum)
+    )][]
+    fold.out <- fold.ord[, mlr3resampling:::stratified_group_cv_RSS_interface(stratum-1, g.int, 2L)+1L]
+    fwide <- dcast(data.table(fold.ord, fold.out), g.int + fold.out ~ Stratum, length)
+    for(f in 1:2){
+      fwide[
+      , paste0("f", f, "s", 1:2) := lapply(.SD, function(x)cumsum(ifelse(fold.out==f, x, 0)))
+      , .SDcols=paste0("s", 1:2)][]
+    }
+    print(fwide)
+    print(table(fold.ord$stratum, fold.out))
+  }
+})
+
 test_that("folds ok for AZtrees(group,stratum)", {
   data(AZtrees, package="mlr3resampling")
   trees_task <- mlr3::as_task_classif(AZtrees, target="y")


### PR DESCRIPTION
with old code (key by freq) we have
```
Key: <g.int, fold.out>
   g.int fold.out    s1    s2  f1s1  f1s2  f2s1  f2s2
   <int>    <int> <int> <int> <num> <num> <num> <num>
1:     1        1     5     3     5     3     0     0
2:     2        2     1     2     5     3     1     2
3:     3        2     1     2     5     3     2     4
4:     4        2     1     2     5     3     3     6
5:     5        2     3     0     5     3     6     6
6:     6        1     1     1     6     4     6     6
```
above is bad because ideal is 6 5 but we get 6 4 and 6 6.

* 1 2 has same RSS and number of samples as 3 0
* all three 1 2 groups go into fold 2, putting it at 3 6, already over ideal of 5 before 3 0 and 1 1 are considered.

below is with new cod, good because 3 0 group is considered before 1 2 groups.
```
   g.int fold.out    s1    s2  f1s1  f1s2  f2s1  f2s2
   <int>    <int> <int> <int> <num> <num> <num> <num>
1:     1        1     5     3     5     3     0     0
2:     2        2     3     0     5     3     3     0
3:     3        2     1     2     5     3     4     2
4:     4        2     1     2     5     3     5     4
5:     5        1     1     2     6     5     5     4
6:     6        2     1     1     6     5     6     5
```
this is a simple example which can be used to justify the neg_freq sort heuristic. (it is also more consistent with the RSS minimization heuristic, which prioritizes groups with counts in more frequent classes)